### PR TITLE
hid filetypes on files

### DIFF
--- a/src/repl/Input/ComponentSelector.svelte
+++ b/src/repl/Input/ComponentSelector.svelte
@@ -7,6 +7,12 @@
 
   let editing = null;
 
+  const cleanTitle = title => {
+    return title.split('-')
+      .map(w => w[0].toUpperCase() + w.substr(1).toLowerCase())
+      .join(' ')
+  }
+
   function selectComponent(component) {
     if ($selected !== component) {
       editing = null;
@@ -187,13 +193,15 @@
 
   .input-sizer {
     color: #ccc;
+    left: 0;
+    top: 0;
   }
 
   input {
     position: absolute;
     width: 100%;
-    left: 16px;
-    top: 12px;
+    left: 11px;
+    top: 7px;
     font: 400 12px/1.5 var(--font);
     border: none;
     color: var(--flash);
@@ -329,7 +337,7 @@
               class="editable"
               title="edit component name"
               on:click={() => editTab(component)}>
-              {component.name}
+              {cleanTitle(component.name)}
             </div>
 
             <span class="remove" on:click={() => remove(component)}>


### PR DESCRIPTION
- hid file type for tabs but kept the file type in the pale version when editing so users can figure out what it is
- cleaned up file names
- fixed styling issue

<img width="1295" alt="Screen Shot 2020-08-05 at 10 21 48 AM" src="https://user-images.githubusercontent.com/10744026/89424214-825a8480-d705-11ea-94d7-30cd9b08df01.png">
<img width="1295" alt="Screen Shot 2020-08-05 at 10 21 52 AM" src="https://user-images.githubusercontent.com/10744026/89424217-82f31b00-d705-11ea-89c9-64d2e021b50a.png">
