### PR TITLE
code editor open by default

### DIFF
--- a/src/repl/Repl.svelte
+++ b/src/repl/Repl.svelte
@@ -235,7 +235,7 @@
     {fixed}>
     <section slot="a">
       <ComponentSelector {handle_select} />
-      <PaneWithPanel pos={100} panel="Custom Code">
+      <PaneWithPanel pos={50} panel="Custom Code">
         <div slot="main">buttons here</div>
 
         <div slot="panel-body" style="display: flex; height: 100%;">


### PR DESCRIPTION
50% code editor height


<img width="1295" alt="Screen Shot 2020-08-08 at 9 23 45 PM" src="https://user-images.githubusercontent.com/10744026/89722918-76005100-d9bd-11ea-9611-acfd072ce088.png">
