### PR TITLE
Intermediate preview

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -143,6 +143,70 @@ export const DEFAULT_COMPONENTS_NAMED = {
   'style.js': DEFAULT_COMPONENT_STYLE,
 };
 
+export const INTERMEDIATE_DATA_APP = {
+  type: 'svelte',
+  name: 'App',
+  source: `<script>
+  import localData from './data.json';
+	import getData from './data.js';
+	
+	const whenItems = Promise.resolve(getData(localData));
+</script>
+
+<style>
+	pre.data {
+		white-space: pre-wrap;
+		word-break: break-all
+	}
+</style>
+
+{#await whenItems}
+  <p>Loading...</p>
+{:then items}
+	<pre class='data'>{JSON.stringify(items, null, 2)}</pre>
+{:catch error}
+	<p style="color: red">{error.message}</p>
+{/await}`
+}
+
+export const INTERMEDIATE_RENDERER_APP = {
+  type: 'svelte',
+  name: 'App',
+  source: `<script>
+  import localData from './data.json';
+	import getData from './data.js';
+	import * as renderers from './renderers.js'
+	
+	const whenItems = Promise.resolve(getData(localData));
+	const itemRenderer = renderers.itemRenderer || renderers.default;
+</script>
+
+<div id='images' />
+
+{#await whenItems}
+<p>Loading...</p>
+{:then items}
+{#await Promise.resolve(itemRenderer(
+      items.map(({ src }) => src)
+    ))}
+<p>Loading...</p> 
+{:then images}
+	{#each images as image}
+		<img src={image.src} alt="item"/>
+	{/each}
+{:catch error}
+<p style="color: red">{error.message}</p>
+{/await}
+{:catch error}
+<p style="color: red">{error.message}</p>
+{/await}`
+}
+
+export const INTERMEDIATE_APP_MAP = {
+  'data.js': INTERMEDIATE_DATA_APP,
+  'renderers.js': INTERMEDIATE_RENDERER_APP
+}
+
 export const DEFAULT_SVELTE_URL = 'https://unpkg.com/svelte@latest';
 
 export const DEFAULT_WORKERS_URL = 'workers';

--- a/src/repl/Output/index.svelte
+++ b/src/repl/Output/index.svelte
@@ -69,7 +69,7 @@
   let css_editor;
   const setters = {};
 
-  let view = 'result';
+  export let view = 'result';
   let selected_type = '';
   let markdown = '';
 </script>
@@ -148,10 +148,10 @@
   {/if}
 </div>
 
-<!-- component viewer -->
+<!-- component viewer/intermediate output -->
 <div
   class="tab-content"
-  class:visible={selected_type !== 'md' && view === 'result'}>
+  class:visible={selected_type !== 'md' && (view === 'result' || view === 'intermediate')}>
   <Viewer
     bind:this={viewer}
     bind:error={runtimeError}
@@ -202,11 +202,4 @@
 <!-- markdown output -->
 <div class="tab-content" class:visible={selected_type === 'md'}>
   <iframe title="Markdown" srcdoc={markdown} />
-</div>
-
-<!-- intermediate output -->
-<div
-  class="tab-content"
-  class:visible={selected_type !== 'md' && view === 'intermediate'}>
-  <div>hi</div>
 </div>

--- a/src/repl/workers/bundler/index.js
+++ b/src/repl/workers/bundler/index.js
@@ -213,19 +213,19 @@ async function get_bundle(uid, mode, cache, lookup) {
         cache[id] && cache[id].code === code
           ? cache[id].result
           : self.svelte.compile(
-              code,
-              Object.assign(
-                {
-                  generate: mode,
-                  format: 'esm',
-                  dev: true,
-                  filename: name + '.svelte',
-                },
-                has_loopGuardTimeout_feature() && {
-                  loopGuardTimeout: 100,
-                }
-              )
-            );
+            code,
+            Object.assign(
+              {
+                generate: mode,
+                format: 'esm',
+                dev: true,
+                filename: name + '.svelte',
+              },
+              has_loopGuardTimeout_feature() && {
+                loopGuardTimeout: 100,
+              }
+            )
+          );
 
       new_cache[id] = { code, result };
 


### PR DESCRIPTION
set up intermediate preview tab
- made App.svelte for previewing data.js and renderers.js
- either the whole piling interface bundles or the preview bundles, since users can only see one at a time and to enable faster previewing at intermediate steps

<img width="1295" alt="Screen Shot 2020-08-18 at 12 42 58 AM" src="https://user-images.githubusercontent.com/10744026/90471306-d6913b80-e0eb-11ea-93cc-b27654a3cc51.png">
<img width="1295" alt="Screen Shot 2020-08-18 at 12 42 54 AM" src="https://user-images.githubusercontent.com/10744026/90471305-d5f8a500-e0eb-11ea-8e76-e51980d4eea1.png">