### PR TITLE
save pile state across runs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,17 +31,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
-      "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@flekschas/utils": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.23.0.tgz",
-      "integrity": "sha512-RN1pQwFzRUjuigHal6S/+t/muI2kU4n/sNU4qH3CeLXjbXHyCjNg3ZHGNEyuJCEGCTqzeyYNT3SiB8YZUA+nfw=="
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@flekschas/utils/-/utils-0.23.1.tgz",
+      "integrity": "sha512-miAac7yeMj1qZflakFdvypXJH967wIzutBD9Rb/IeSX6pUOVoAeeIvNrbj5PK0QoLkwZvbhJIInJTHvVTwc0bQ=="
     },
     "@material/animation": {
       "version": "3.1.0",
@@ -5657,11 +5657,11 @@
       "dev": true
     },
     "piling.js": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/piling.js/-/piling.js-0.7.3.tgz",
-      "integrity": "sha512-jfQiU0HUFMP9MOmpw0uTwHQ5jQ4Xm1YJKc48zRokOzC2Ul4BLqAs4O/gJHySwkF1p5zw5c3IgWnFDknXdP+uhQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/piling.js/-/piling.js-0.7.4.tgz",
+      "integrity": "sha512-SaVKWC4i6FbuotRKb47O6p/p6xduzqZz7VDy0F0McEV5lTqB4Dfa3NhCXdmD3toLkow+dPPlbhIYvZ4OqGNq8A==",
       "requires": {
-        "@flekschas/utils": "~0.23.0",
+        "@flekschas/utils": "~0.23.1",
         "camera-2d-simple": "~2.2.0",
         "deep-equal": "~1.1.0",
         "dom-2d-camera": "~1.0.1",
@@ -6836,9 +6836,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regexp.prototype.flags": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "estree-walker": "^0.9.0",
     "marked": "^0.8.2",
     "papaparse": "^5.2.0",
-    "piling.js": "^0.7.3",
+    "piling.js": "^0.7.4",
     "pixi.js": "^5.1.6",
     "sourcemap-codec": "^1.4.6",
     "svelte": "^3.23.2",

--- a/public/piling-proxy.js
+++ b/public/piling-proxy.js
@@ -1,5 +1,6 @@
 const {
   createLibrary,
+  createLibraryFromState,
   createMatrixPreviewAggregator,
   createMatrixCoverAggregator,
   createRepresentativeAggregator,
@@ -17,6 +18,7 @@ export default createPilingJs;
 
 export {
   createLibrary,
+  createLibraryFromState,
   createMatrixPreviewAggregator,
   createMatrixCoverAggregator,
   createRepresentativeAggregator,


### PR DESCRIPTION
I spent a while trying to get piling.js to run locally but was unable to build it for some reason—here is a PR using `piling.subscribe` to subscribe to `itemUpdate` event
- preserves pile states across page refreshes and repl runs, but overwrites using user's code if necessary

before editing data transformer:
<img width="1355" alt="Screen Shot 2020-08-20 at 3 41 52 PM" src="https://user-images.githubusercontent.com/10744026/90817594-0f076400-e2fc-11ea-9917-8a5178c45a04.png">

after editing data transformer and pressing "Run"
<img width="1355" alt="Screen Shot 2020-08-20 at 3 42 05 PM" src="https://user-images.githubusercontent.com/10744026/90817590-0c0c7380-e2fc-11ea-9705-be35c9070819.png">
